### PR TITLE
feat: add Astraflow provider support (global & China endpoints)

### DIFF
--- a/LLM/llm_config.json
+++ b/LLM/llm_config.json
@@ -31,5 +31,27 @@
     "context_window": 1000000,
     "max_output_tokens": 384000,
     "enable_thinking": true
+  },
+  "astraflow": {
+    "provider": "astraflow",
+    "api_key": "sk",
+    "base_url": "https://api-us-ca.umodelverse.ai/v1",
+    "model": "gpt-4o-mini",
+    "enabled": false,
+    "is_custom": false,
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "enable_thinking": false
+  },
+  "astraflow_cn": {
+    "provider": "astraflow_cn",
+    "api_key": "sk",
+    "base_url": "https://api.modelverse.cn/v1",
+    "model": "gpt-4o-mini",
+    "enabled": false,
+    "is_custom": false,
+    "context_window": 128000,
+    "max_output_tokens": 16384,
+    "enable_thinking": false
   }
 }

--- a/LLM/llm_config_manager.py
+++ b/LLM/llm_config_manager.py
@@ -66,6 +66,22 @@ class LLMConfigManager:
             "is_custom": False,
             "context_window": 200000,
             "max_output_tokens": 8192,
+        },
+        "astraflow": {
+            "base_url": "https://api-us-ca.umodelverse.ai/v1",
+            "model": "gpt-4o-mini",
+            "env_var": "ASTRAFLOW_API_KEY",
+            "is_custom": False,
+            "context_window": 128000,
+            "max_output_tokens": 16384,
+        },
+        "astraflow_cn": {
+            "base_url": "https://api.modelverse.cn/v1",
+            "model": "gpt-4o-mini",
+            "env_var": "ASTRAFLOW_CN_API_KEY",
+            "is_custom": False,
+            "context_window": 128000,
+            "max_output_tokens": 16384,
         }
     }
 
@@ -278,7 +294,7 @@ class LLMConfigManager:
         ]
 
     def get_default_provider(self) -> Optional[str]:
-        priority = ["deepseek", "openai", "claude"]
+        priority = ["deepseek", "openai", "claude", "astraflow", "astraflow_cn"]
         for provider in priority:
             if provider in self.configs and self.configs[provider].enabled:
                 return provider


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a built-in LLM provider, supporting both the global and China endpoints.

### What is Astraflow?
- OpenAI-compatible AI model aggregation platform supporting **200+ models**
- Global site: https://astraflow.ucloud-global.com
- China site:  https://astraflow.ucloud.cn

### Changes

#### `LLM/llm_config_manager.py`
- Registers `astraflow` (global) and `astraflow_cn` (China) in `DEFAULT_CONFIGS` with their respective `base_url` and `env_var` values.
- Adds both providers to the `get_default_provider()` priority list so they are auto-selected when configured.

#### `LLM/llm_config.json`
- Adds skeleton entries for `astraflow` and `astraflow_cn` (placeholder `api_key` of `"sk"`, disabled by default) — consistent with existing entries for `openai`, `claude`, and `deepseek`.

### Environment variables
| Provider | Environment Variable |
|---|---|
| Astraflow (global) | `ASTRAFLOW_API_KEY` |
| Astraflow (China)  | `ASTRAFLOW_CN_API_KEY` |

### No breaking changes
Both new entries are **disabled by default** (`"enabled": false`) in `llm_config.json` and the `env_var` auto-load path already works via `_load_from_env()`, so existing users are unaffected.
