### PR TITLE
fix: improve chart recommendation confidence

### DIFF
--- a/LLM/chart_selector.py
+++ b/LLM/chart_selector.py
@@ -477,7 +477,8 @@ _BOOST_TABLE: List[tuple] = [
 
     # — RELATIONSHIP —
     (["散点图", "散点", "scatter", "scatter plot", "相关性", "correlation",
-      "两变量关系", "变量关系", "变量之间的关系"],
+      "两变量关系", "变量关系", "变量之间的关系", "的关系", "之间关系",
+      "relationship between", "association between"],
      ["Scatter_Plot"], 22),
 
     (["相关性", "correlation", "两变量关系"],
@@ -539,6 +540,8 @@ _COLUMN_PATTERN_TABLE: List[tuple] = [
 
 # Build a fast lookup: chart_id -> chart dict
 _CHART_INDEX: Dict[str, Dict[str, Any]] = {c["chart_id"]: c for c in _CHARTS}
+
+_MINIMUM_VALID_SCORE = 1
 
 
 def _score_chart(chart: Dict[str, Any], intent_lower: str, col_lower: List[str]) -> int:
@@ -606,10 +609,11 @@ def select_charts(
     intent_lower = user_intent.lower()
     col_lower = [c.lower() for c in (available_columns or [])]
 
-    scored = [
-        (chart, _score_chart(chart, intent_lower, col_lower))
-        for chart in _CHARTS
-    ]
+    scored = []
+    for chart in _CHARTS:
+        score = _score_chart(chart, intent_lower, col_lower)
+        if score >= _MINIMUM_VALID_SCORE:
+            scored.append((chart, score))
     scored.sort(key=lambda t: -t[1])
 
     results = []
@@ -647,7 +651,8 @@ def format_selection_result(candidates: List[Dict[str, Any]]) -> str:
     if not candidates:
         return (
             "No matching charts found in the registry. "
-            "Use a chart_id from the complete list in the system prompt."
+            "Use `ask_user` to confirm the visualization goal "
+            "before selecting a chart."
         )
 
     lines: List[str] = [

--- a/skills/chart/SKILL.md
+++ b/skills/chart/SKILL.md
@@ -2,7 +2,7 @@
 name: chart
 description: 根据当前数据选择并生成合适的业务图表（visualization 可视化）
 icon: 📊
-allowedTools: [get_schema, query_data, select_chart, generate_chart]
+allowedTools: [get_schema, query_data, select_chart, ask_user, generate_chart]
 ---
 # 图表分析
 
@@ -13,7 +13,8 @@ allowedTools: [get_schema, query_data, select_chart, generate_chart]
 1. Use `get_schema` to inspect available tables and fields.
 2. Use `query_data` to verify the minimum data needed for the chart and avoid guessing column names.
 3. Use `select_chart` when the user intent does not already determine a chart type.
-4. Use `generate_chart` with the selected chart id and explicit field mapping.
+4. If `select_chart` has no valid candidate, use `ask_user` to clarify the visualization goal; do not call `generate_chart` directly.
+5. Use `generate_chart` with the selected chart id and explicit field mapping.
 
 ## Implementation reference
 

--- a/tests/test_chart_selector.py
+++ b/tests/test_chart_selector.py
@@ -1,0 +1,43 @@
+import unittest
+
+from LLM.chart_selector import format_selection_result, select_charts
+
+
+class ChartSelectorTests(unittest.TestCase):
+    def test_relationship_intent_prefers_positive_scatter_candidate(self):
+        candidates = select_charts(
+            "客户年龄与消费金额的关系", ["客户年龄", "消费金额"]
+        )
+
+        self.assertEqual("Scatter_Plot", candidates[0]["chart_id"])
+        self.assertGreater(candidates[0]["_score"], 0)
+
+    def test_unmatched_intent_returns_no_candidates(self):
+        candidates = select_charts("zzqv_unmatched_intent")
+
+        self.assertEqual([], candidates)
+
+    def test_positive_candidates_do_not_include_zero_score_fillers(self):
+        candidates = select_charts("line chart", top_n=3)
+
+        self.assertTrue(candidates)
+        self.assertTrue(
+            all(candidate["_score"] > 0 for candidate in candidates)
+        )
+
+    def test_empty_candidates_request_ask_user_clarification(self):
+        result = format_selection_result([])
+
+        self.assertIn("ask_user", result)
+        self.assertIn("confirm", result.lower())
+        self.assertNotIn("generate_chart", result)
+        self.assertNotIn("complete list", result)
+
+    def test_monthly_sales_trend_still_prefers_line_chart(self):
+        candidates = select_charts("各月销售额趋势")
+
+        self.assertEqual("Line_Chart", candidates[0]["chart_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- recognize common Chinese and English relationship expressions when recommending `Scatter_Plot`
- exclude candidates below the minimum valid score instead of padding `top_n` with zero-score charts
- require `ask_user` clarification when no valid chart candidate exists, and expose that route in the chart skill

## Reproduction and root cause

Before this change, an intent such as `客户年龄与消费金额的关系` did not match the scatter-plot relationship keywords. The selector then sorted every registry entry, including entries scored `0`, so unrelated charts such as `Marimekko_ABS` could be returned simply to fill `top_n`.

The two root causes were:

1. common relationship phrases were missing from the relationship boost table;
2. `select_charts` sliced the full scored registry without removing zero-score candidates.

## Behavior after this change

- relationship intents recommend `Scatter_Plot` with a positive score
- unmatched intents return no candidates
- positive candidates are no longer padded with zero-score charts
- empty selections explicitly direct the agent to call `ask_user` before selecting or generating a chart

The `select_charts(user_intent, available_columns, top_n)` signature and candidate structure are unchanged. The only cardinality change is that the function now returns `0..top_n` valid candidates rather than always filling `top_n`.

## Tests

Passed:

```text
python3.11 -m unittest discover -s tests -p 'test_chart_selector.py' -v
python3.11 -m compileall -q LLM agent
uvx ruff check LLM/chart_selector.py tests/test_chart_selector.py
uvx flake8 --select=E9,F63,F7,F82 LLM/chart_selector.py tests/test_chart_selector.py
git diff --check upstream/main...HEAD
```

The new unittest suite covers five regression scenarios and reports `Ran 5 tests` / `OK`.

The repository's full Flake8 command still reports 37 pre-existing findings in `LLM/chart_selector.py` (`E402` x1 and `E501` x36). This count exactly matches `upstream/main`; the new test file and changed lines introduce no additional Flake8 findings. Existing style debt was intentionally left out of this focused fix.

No chart registry refactor, field-type API, AutoML behavior, or unrelated cleanup is included.
