### PR TITLE
docs: propose analysis planning architecture

### DIFF
--- a/docs/15-analysis-planning-architecture-rfc.md
+++ b/docs/15-analysis-planning-architecture-rfc.md
@@ -1,0 +1,429 @@
+# 分析决策与呈现规划架构 RFC
+
+> 状态：**提案，等待维护者反馈；未开始实现**
+> 日期：2026-08-23
+> 范围：分析方法选择、数据适用性验证、置信度与澄清、分析结果契约、呈现形式规划
+> 兼容原则：保留现有 Skill、`run_analysis`、`select_chart` 和 `generate_chart` 公共入口，渐进迁移
+
+## 0. 希望维护者确认的事项
+
+这份 RFC 只描述方向和验证方式，不修改生产代码。希望维护者确认：
+
+1. 是否认可引入统一、结构化的 `AnalysisPlan` 作为分析决策真相源？
+2. 是否接受“先在贡献者本地离线影子评测并记录结果，达到门槛后再提交代码 PR”的方式？
+   本提案不计划提交一个仅用于运行时影子 Planner 的独立 PR。
+3. 如果方向可行，后续代码更适合一个完整 PR，还是按数据契约、能力注册表、Planner、
+   Presentation Planner 拆成多个可独立审查的 PR？
+
+在维护者确认方向前，不开始生产代码改造。
+
+## 1. 背景
+
+项目已经具备较完整的数据分析执行能力：
+
+- `agent/skill_discovery.py` 使用语义向量、词法和名称信号检索相关 Skill。
+- `skills/*/SKILL.md` 提供回归、聚类、时序预测等分析 SOP。
+- `Function/Analyze/registry.py` 注册分析实现并由 `run_analysis` 执行。
+- `LLM/chart_selector.py` 根据意图和字段名推荐图表。
+- `profile_data`、`get_schema` 和知识库为模型提供数据与业务上下文。
+- 报告、看板和导出工具已有 proposal/confirm 人工确认流程。
+
+当前主要缺口不是分析算法数量，而是分析决策分散在 Skill 检索、系统 Prompt、斜杠命令、
+LLM 自由判断、分析注册表和图表规则中。系统可以执行某种方法，但缺少一个统一对象说明：
+
+- 为什么选择这个方法；
+- 当前数据是否满足方法条件；
+- 哪些假设需要验证；
+- 结果应产生哪些表、指标和诊断；
+- 为什么最终选择文本、表格、图表、报告或看板；
+- 置信度不足时为什么执行、澄清或停止。
+
+## 2. 当前调用链与问题
+
+```mermaid
+flowchart LR
+    U["用户自然语言"] --> SR["Skill 语义检索"]
+    SR --> L1["LLM 判断是否加载 Skill"]
+    L1 --> Q["LLM 编写 SQL"]
+    L1 --> M["LLM 选择 analysis_name"]
+    Q --> RA["通用 run_analysis"]
+    M --> RA
+    RA --> R["Markdown + 固定结果表"]
+    R --> L2["LLM 决定解释与呈现"]
+    L2 --> CS["chart_selector 规则评分"]
+    CS --> GC["generate_chart"]
+    L2 --> O["文本 / 报告 / 看板"]
+    D["Schema / Profile / 业务知识"] -. "主要以文本提供" .-> L1
+```
+
+### 2.1 Skill 检索不是方法适用性验证
+
+Skill 检索能找到语义上相关的方法，但没有统一结合目标变量类型、样本量、时间频率、类别
+平衡、缺失率、泄漏风险、用户目标和可解释性要求，确定候选方法是否真正可用。
+
+### 2.2 分析注册表只描述“怎么运行”
+
+现有分析注册表主要包含 ID、描述、参数名、输出表和执行函数，尚未统一声明：
+
+- 支持的问题类型；
+- 输入字段角色与类型；
+- 最低数据量和质量要求；
+- 前置条件、禁用条件和诊断；
+- 成本与可解释性；
+- 结构化输出契约和推荐呈现形式。
+
+### 2.3 数据画像没有成为稳定的机器决策输入
+
+数据概况已经能够计算字段类型、缺失和分布，但这些结果主要作为 Markdown 交给 LLM。
+`select_charts(user_intent, available_columns, top_n)` 只接收字段名，无法可靠判断字段类型、
+基数、时间连续性、正负值、单位、粒度和数据点数量。
+
+### 2.4 通用参数接口承载了不同含义
+
+`run_analysis` 用 `target_column`、`groupby_column`、`n_deciles` 驱动多种分析。不同方法可能
+复用同一个参数表达目标字段、算法选项、分桶数量或聚类数量，导致参数难以类型化验证，
+也增加模型调用错误的风险。
+
+### 2.5 分析结果与呈现规划断开
+
+分析模块返回 Markdown 和若干结果表，随后 LLM 再次依据上下文决定图表或文档。中间缺少
+统一 `AnalysisResult`，无法稳定声明核心指标、诊断、警告、来源、推荐图表和可用证据。
+
+### 2.6 置信度和澄清策略不统一
+
+Skill 检索、图表评分和 LLM 判断分别拥有不同阈值。第一、第二候选接近、数据条件不足、
+方法假设失败等情况没有统一的执行/澄清/拒绝策略。
+
+### 2.7 规则分散导致维护漂移
+
+同一方法的工作流和呈现建议可能同时存在于系统 Prompt、斜杠命令、Skill 和注册表中。
+新增或修改方法时需要人工保持多处一致，容易出现 Prompt 已更新但运行契约未更新的情况。
+
+## 3. 目标与非目标
+
+### 3.1 目标
+
+1. 用统一 `AnalysisPlan` 记录一次分析的目标、数据、方法、参数、验证、输出和呈现计划。
+2. 让 LLM 负责语义理解和候选生成，让确定性代码负责数据兼容、方法条件和安全边界。
+3. 在执行前发现不适用方法、字段错误、参数冲突和证据不足。
+4. 用统一置信度和候选分差决定执行、澄清或停止。
+5. 让呈现方式同时考虑业务问题、数据形状、分析结果和受众，而非只匹配图表关键词。
+6. 保持现有公开工具入口兼容，允许渐进迁移和回退。
+7. 在代码提交前提供可复现的本地离线对照结果。
+
+### 3.2 非目标
+
+- 本阶段不建设 AutoML 平台或自动超参数搜索系统。
+- 不允许 LLM 绕过确定性验证器直接执行不兼容计划。
+- 不一次性重写所有分析算法、图表实现和输出工具。
+- 不取消现有 Skill；Skill 继续承担方法 SOP 和用户可扩展能力。
+- 不在上游生产运行时长期维护双 Planner 或流量影子路径。
+- 本 RFC PR 不包含任何生产代码、测试数据或模型调用结果。
+
+## 4. 建议目标架构
+
+```mermaid
+flowchart TB
+    U["用户请求"] --> IP["Intent Parser\n结构化业务目标"]
+    DS["Schema + Data Profile"] --> CB["Context Builder"]
+    KB["指标口径 / 业务知识"] --> CB
+    IP --> CP["Candidate Planner"]
+    CB --> CP
+    AR["Analysis Capability Registry"] --> CP
+    CP --> PV["Plan Scorer + Validator"]
+    PV -->|"歧义或条件不足"| AU["ask_user"]
+    AU --> IP
+    PV -->|"验证通过"| AP["AnalysisPlan"]
+    AP --> EX["Execution Engine"]
+    EX --> RV["Result Validator\n假设与质量诊断"]
+    RV -->|"结果有效"| PP["Presentation Planner"]
+    RV -->|"方法不适用"| CP
+    VR["Visualization Capability Registry"] --> PP
+    PP --> T["文本 / 表格"]
+    PP --> C["图表"]
+    PP --> O["报告 / 看板"]
+    EX --> EV["Evidence + Provenance"]
+    RV --> EV
+    EV --> PP
+```
+
+核心边界是：
+
+- **LLM**：理解用户语义、补全业务目标、生成有限候选、解释有效结果。
+- **确定性 Planner/Validator**：验证字段类型、方法条件、参数、置信度和候选分差。
+- **执行层**：只执行已经验证的计划，不负责重新解释用户意图。
+- **呈现层**：根据结构化结果选择表现形式，不从原始用户句子重新猜测。
+
+## 5. 核心数据契约
+
+### 5.1 AnalysisIntent
+
+```text
+goal                 描述 | 比较 | 诊断 | 解释 | 预测 | 分群
+question_type        趋势 | 关系 | 构成 | 分布 | 异常 | 分类 | 预测
+target               目标指标或标签
+dimensions           分组、对比和切片维度
+time_scope           时间范围、频率和预测期
+audience             分析师 | 业务负责人 | 管理层
+artifact             对话 | 图表 | 报告 | 看板 | 导出
+constraints          可解释性、速度、精度和业务限制
+ambiguities          尚未确定且可能改变方法的事项
+```
+
+### 5.2 DataContext
+
+```text
+table / source
+row_count
+columns[]
+  - physical_type
+  - semantic_role
+  - nullable / missing_rate
+  - cardinality
+  - numeric_range / allows_negative
+  - time_frequency / continuity
+grain
+metric_contracts
+quality_warnings
+```
+
+`profile_data` 可继续输出人类可读 Markdown，但同时应提供稳定 JSON 结构供 Planner 使用。
+
+### 5.3 AnalysisCapability
+
+每个分析方法在注册表中声明：
+
+```text
+method_id
+supported_goals
+input_roles_and_types
+minimum_data_requirements
+preconditions
+incompatibilities
+parameter_schema
+required_diagnostics
+output_contract
+presentation_hints
+cost_and_explainability
+```
+
+### 5.4 AnalysisPlan
+
+```text
+intent
+dataset
+method_id
+field_roles
+parameters
+prechecks
+expected_outputs
+presentation_hints
+confidence
+runner_up_margin
+reason_codes
+```
+
+### 5.5 AnalysisResult 与 PresentationPlan
+
+`AnalysisResult` 统一描述结果表、核心指标、诊断、警告、假设状态、数据来源和执行参数。
+`PresentationPlan` 再根据问题、受众、结果类型和数据规模选择文本、表格、图表、报告或看板。
+
+## 6. 方法选择与澄清策略
+
+候选方法建议从以下维度评分：
+
+1. 用户目标和问题类型匹配度；
+2. 字段角色、数据类型和样本量兼容性；
+3. 数据质量和方法假设满足程度；
+4. 用户对准确性、速度和可解释性的要求；
+5. 计算成本；
+6. 用户明确指定的方法偏好；
+7. 第一候选与第二候选的分差。
+
+决策输出只能是：
+
+- **execute**：候选通过全部硬约束，置信度及分差达到门槛；
+- **clarify**：多个合法候选会产生实质不同结论，或缺少会改变方法的业务信息；
+- **blocked**：数据不满足任何方法的必要条件；
+- **fallback**：高级方法不适用，但存在经过验证的简单描述性方案。
+
+每次决定都返回稳定 `reason_codes`，便于测试、日志分析和向用户解释。
+
+## 7. 可视化与呈现规划
+
+图表注册表应逐步升级为可视化能力注册表，除图表名称和字段角色外，还声明：
+
+- 支持的分析目标和结果类型；
+- 每个 role 的字段类型；
+- 类别基数、数据点数量和系列数范围；
+- 是否允许负值、是否需要排序或归一化；
+- 禁用条件和降级图表；
+- 对应的解释模板和无障碍要求。
+
+Presentation Planner 不应把“用户提到关系”直接等价为散点图，而应先判断：
+
+- 是否已有统计分析结果；
+- x/y 是否为数值字段；
+- 是否需要展示置信区间、残差、预测区间或类别分组；
+- 受众需要精确表格、诊断视图还是管理摘要；
+- 是否根本不需要图表。
+
+## 8. 兼容与迁移策略
+
+### 8.1 保持现有入口
+
+- `run_analysis(...)` 保留，内部可以逐步转为执行已经验证的计划。
+- `select_charts(...)` 保留为兼容适配器；新接口可接收 `DataContext` 和 `AnalysisResult`。
+- `generate_chart(...)` 继续负责渲染，但在渲染前增加类型化数据契约校验。
+- Skill 继续存在，逐步把重复的硬约束迁移到能力注册表，Skill 保留业务 SOP 和解释要求。
+- 斜杠命令继续工作，不要求用户改变已有使用方式。
+
+### 8.2 可回退
+
+新 Planner 需要配置开关。若代码 PR 上线后发现回归，可以切回现有决策路径；执行算法、图表
+渲染器和数据源接口不随 Planner 重写，从而缩小回退范围。
+
+## 9. 本地离线影子评测方案
+
+### 9.1 原则
+
+影子 Planner 不作为独立上游 PR，也不进入生产流量路径。维护者认可本 RFC 后，贡献者在本地
+分支实现候选 Planner，并让新旧 Planner 对同一批冻结案例独立生成决策，执行结果不展示给
+真实用户，也不写入真实业务数据。
+
+只有评测结果达到约定门槛，才提交生产代码 PR。实现 PR 同时附带评测摘要和可复现说明。
+
+### 9.2 冻结评测集
+
+建议至少 100 个匿名、合成或公开可分享案例，覆盖：
+
+- 描述统计、趋势、关系、构成、分布、分类、预测和聚类；
+- 数值、类别、时间、地理、ID 和文本字段组合；
+- 样本不足、目标类型错误、缺失严重、类别失衡和时间不连续；
+- 第一、第二候选接近，需要澄清的歧义场景；
+- 中文、英文和中英混合表达；
+- 文本、表格、单图、多图、报告和看板呈现目标；
+- 现有斜杠命令和 Skill 的关键兼容场景。
+
+案例只保存结构化意图、匿名 schema/profile、预期决策和判定理由，不包含密钥或未经授权的
+真实业务数据。
+
+### 9.3 对照记录
+
+每个案例记录：
+
+```text
+case_id
+baseline_commit / candidate_commit
+model_provider / model / temperature
+input_intent / data_context
+baseline_decision / candidate_decision
+expected_method / expected_presentation
+confidence / runner_up_margin / reason_codes
+validation_errors
+latency / model_calls
+pass_or_fail / reviewer_note
+```
+
+若模型无法设置完全确定性参数，对候选 Planner 重复运行三次并记录一致率。
+
+### 9.4 建议提交门槛
+
+正式阈值由维护者确认。初始建议为：
+
+- 方法选择准确率较基线提升至少 10 个百分点；
+- 数据不兼容计划比例下降至少 50%，且不高于 5%；
+- 呈现形式适配准确率较基线提升至少 10 个百分点；
+- 应澄清案例的召回率不低于 90%；
+- 不应澄清案例的误澄清率相对基线恶化不超过 5 个百分点；
+- 现有命令、Skill、工具 Schema 和分析执行测试无回归；
+- 新增模型调用和 P95 延迟在维护者接受的预算内；
+- 所有失败案例均分类为意图解析、数据上下文、能力元数据、评分、验证或呈现问题。
+
+评测报告应同时展示绝对数量、比例和失败案例，不只报告一个总分。
+
+### 9.5 提交流程
+
+```text
+RFC 文档 PR（当前）
+    ↓ 维护者认可方向和评测门槛
+本地建立冻结评测集并测量旧路径基线
+    ↓
+本地实现候选 Planner 与兼容适配器（不提交影子 PR）
+    ↓
+本地离线影子对照，记录结果和失败分类
+    ↓ 达到门槛
+提交生产代码 PR，并附评测摘要、兼容性和回退说明
+```
+
+如果未达到门槛，继续在本地修订或停止方案，不把不成熟的 Planner 提交给上游维护。
+
+## 10. 预期收益
+
+### 10.1 分析正确性
+
+方法选择从“语义上像某个 Skill”升级为“目标匹配且数据条件验证通过”，减少分类目标调用线性
+回归、短时间序列调用复杂预测模型、类别过多仍使用饼图等错误。
+
+### 10.2 可解释与可审计
+
+`AnalysisPlan` 保存方法、字段、参数、置信度和 `reason_codes`。用户和维护者可以回答“为什么
+这样分析”，测试也可以直接断言决策，不再只能检查最终文本。
+
+### 10.3 更一致的澄清体验
+
+所有方法和呈现选择共享执行/澄清/阻塞标准，避免图表会澄清、分析方法却直接猜测的行为差异。
+
+### 10.4 更可靠的呈现
+
+呈现方式由结构化结果驱动，预测可以稳定带预测区间，回归可以带系数和诊断，管理层输出可以
+优先结论和风险，而不是仅根据原始用户措辞选一个图表。
+
+### 10.5 更低的长期维护成本
+
+新增分析方法时，开发者在能力注册表中声明输入、条件、输出和呈现提示，减少在 Prompt、Skill、
+命令和工具描述之间重复维护规则。
+
+### 10.6 更安全的开源演进
+
+本地离线影子评测把架构重构从“凭感觉提交”变成“先给基线和对照证据”。上游不需要先合并
+运行时双路径，也不会让真实用户承担试验风险。
+
+## 11. 成本与风险
+
+| 风险 | 影响 | 缓解方式 |
+|---|---|---|
+| 能力元数据维护成本 | 新方法需要声明更多契约 | 提供公共默认值、Schema 校验和注册模板 |
+| Planner 增加延迟 | 多一次结构化规划或验证 | 优先本地确定性过滤，仅对歧义调用 LLM |
+| 离线案例代表性不足 | 本地结果可能高估真实效果 | 覆盖失败场景、语言变化和数据形状；后续只记录匿名反馈指标 |
+| 规则过严 | 合法分析被阻止 | 提供 fallback、reason code 和可配置软门槛 |
+| 规则与 Skill 再次重复 | 形成新的漂移点 | 能力注册表负责硬约束，Skill 只负责 SOP 和解释 |
+| 重构范围过大 | PR 难审查、回归范围大 | 由维护者决定单 PR 或按稳定接口拆分；每步保留适配器 |
+
+## 12. 后续代码范围草案（本 PR 不实施）
+
+可能新增或调整的模块边界：
+
+```text
+agent/planning/models.py          AnalysisIntent / DataContext / AnalysisPlan
+agent/planning/context.py         schema/profile/knowledge 结构化上下文
+agent/planning/candidates.py      候选分析方法生成
+agent/planning/policy.py          评分、置信度、分差与澄清策略
+agent/planning/validator.py       方法和字段适用性验证
+agent/presentation/planner.py     文本、表格、图表和文档规划
+Function/Analyze/registry.py      扩展 AnalysisCapability 元数据
+LLM/chart_selector.py             保留兼容入口，接入类型化可视化约束
+agent/tools/business/data.py      执行已验证计划并返回 AnalysisResult
+```
+
+实际文件和 PR 粒度以维护者反馈为准。
+
+## 13. 请求反馈
+
+如果维护者认为问题判断和方向合理，希望确认第 0 节的三个问题，尤其是：
+
+- 是否接受统一 `AnalysisPlan` 和能力注册表作为后续演进方向；
+- 是否接受在贡献者本地完成离线影子评测、随代码 PR 提交结果摘要，而不先合并运行时影子路径；
+- 希望后续实现以一个完整 PR 还是多个稳定接口 PR 提交。
+
+收到方向确认后，再建立本地评测集和实现计划；在此之前不修改生产行为。

--- a/docs/15-analysis-planning-architecture-rfc.md
+++ b/docs/15-analysis-planning-architecture-rfc.md
@@ -1,42 +1,46 @@
-# 分析决策与呈现规划架构 RFC
+# 分析决策规划架构 RFC
 
-> 状态：**提案，等待维护者反馈；未开始实现**
-> 日期：2026-08-23
-> 范围：分析方法选择、数据适用性验证、置信度与澄清、分析结果契约、呈现形式规划
-> 兼容原则：保留现有 Skill、`run_analysis`、`select_chart` 和 `generate_chart` 公共入口，渐进迁移
+> 状态：**已按维护者意见修订，等待重新审查；未开始实现**
+> 原始提案日期：2026-08-23
+> 本次修订日期：2026-08-25
+> 首期范围：Analysis 侧结构化契约、能力元数据、候选规划、确定性验证、统一决策、结果契约与本地离线评测
+> 兼容原则：保留现有 Skill、`run_analysis` 和分析完成后的呈现链，渐进迁移并允许回退
 
-## 0. 希望维护者确认的事项
+## 0. 本次修订与希望维护者确认的事项
 
-这份 RFC 只描述方向和验证方式，不修改生产代码。希望维护者确认：
+维护者已经认可以下方向：
 
-1. 是否认可引入统一、结构化的 `AnalysisPlan` 作为分析决策真相源？
-2. 是否接受“先在贡献者本地离线影子评测并记录结果，达到门槛后再提交代码 PR”的方式？
-   本提案不计划提交一个仅用于运行时影子 Planner 的独立 PR。
-3. 如果方向可行，后续代码更适合一个完整 PR，还是按数据契约、能力注册表、Planner、
-   Presentation Planner 拆成多个可独立审查的 PR？
+- 使用统一 `AnalysisPlan` 与能力注册表承载分析决策；
+- LLM 负责语义理解，确定性代码负责机器可验证约束；
+- 先做本地离线影子评测，不先合并运行时影子路径。
 
-在维护者确认方向前，不开始生产代码改造。
+本次修订逐项处理命名、Skill 硬约束迁移、评测集抽审、稳定 `reason_codes` 和首期范围五项意见。
+本 RFC PR 仍然只包含文档，不包含生产代码、评测数据或模型调用结果。希望维护者重新审查并确认：
+
+1. 是否认可第 7 节的 `analysis-reason-codes/v1` 初版枚举与兼容规则；
+2. 冻结评测集采用“维护者分层抽审”还是“维护者隐藏/保留案例”；
+3. 是否接受第 9.4 节的建议门槛，并允许在本地开始首期 Analysis 侧实现与评测。
+
+在 PR 合并或维护者明确允许继续前，不开始生产代码改造。
 
 ## 1. 背景
 
 项目已经具备较完整的数据分析执行能力：
 
-- `agent/skill_discovery.py` 使用语义向量、词法和名称信号检索相关 Skill。
-- `skills/*/SKILL.md` 提供回归、聚类、时序预测等分析 SOP。
-- `Function/Analyze/registry.py` 注册分析实现并由 `run_analysis` 执行。
-- `LLM/chart_selector.py` 根据意图和字段名推荐图表。
-- `profile_data`、`get_schema` 和知识库为模型提供数据与业务上下文。
-- 报告、看板和导出工具已有 proposal/confirm 人工确认流程。
+- `agent/skill_discovery.py` 使用语义向量、词法和名称信号检索相关 Skill；
+- `skills/*/SKILL.md` 提供回归、聚类、时序预测等分析 SOP；
+- `Function/Analyze/registry.py` 注册分析实现并由 `run_analysis` 执行；
+- `profile_data`、`get_schema` 和知识库为模型提供数据与业务上下文；
+- `select_chart`、`generate_chart`、报告和看板工具构成现有下游呈现链。
 
-当前主要缺口不是分析算法数量，而是分析决策分散在 Skill 检索、系统 Prompt、斜杠命令、
-LLM 自由判断、分析注册表和图表规则中。系统可以执行某种方法，但缺少一个统一对象说明：
+当前主要缺口不是分析算法数量，而是分析决策分散在 Skill 检索、系统 Prompt、命令提示、
+LLM 自由判断、分析注册表和各分析模块中。系统可以执行某种方法，但缺少统一对象说明：
 
 - 为什么选择这个方法；
-- 当前数据是否满足方法条件；
-- 哪些假设需要验证；
-- 结果应产生哪些表、指标和诊断；
-- 为什么最终选择文本、表格、图表、报告或看板；
-- 置信度不足时为什么执行、澄清或停止。
+- 当前数据是否满足字段、样本量、质量和方法假设；
+- 参数是否合法，哪些诊断必须执行；
+- 为什么执行、澄清、阻塞或降级；
+- 执行后产生了哪些结果表、指标、诊断、警告和证据。
 
 ## 2. 当前调用链与问题
 
@@ -49,8 +53,8 @@ flowchart LR
     Q --> RA["通用 run_analysis"]
     M --> RA
     RA --> R["Markdown + 固定结果表"]
-    R --> L2["LLM 决定解释与呈现"]
-    L2 --> CS["chart_selector 规则评分"]
+    R --> L2["现有解释与呈现链"]
+    L2 --> CS["select_chart 工具"]
     CS --> GC["generate_chart"]
     L2 --> O["文本 / 报告 / 看板"]
     D["Schema / Profile / 业务知识"] -. "主要以文本提供" .-> L1
@@ -58,372 +62,509 @@ flowchart LR
 
 ### 2.1 Skill 检索不是方法适用性验证
 
-Skill 检索能找到语义上相关的方法，但没有统一结合目标变量类型、样本量、时间频率、类别
-平衡、缺失率、泄漏风险、用户目标和可解释性要求，确定候选方法是否真正可用。
+Skill 检索能找到语义相关的方法，但没有统一结合目标变量类型、样本量、时间频率、类别平衡、
+缺失率、用户目标和方法假设，确定候选方法是否真正可用。
 
 ### 2.2 分析注册表只描述“怎么运行”
 
 现有分析注册表主要包含 ID、描述、参数名、输出表和执行函数，尚未统一声明：
 
-- 支持的问题类型；
+- 支持的分析目标；
 - 输入字段角色与类型；
 - 最低数据量和质量要求；
-- 前置条件、禁用条件和诊断；
-- 成本与可解释性；
-- 结构化输出契约和推荐呈现形式。
+- 参数 Schema、依赖、前置条件和禁用条件；
+- 必需诊断和结构化输出契约。
 
 ### 2.3 数据画像没有成为稳定的机器决策输入
 
-数据概况已经能够计算字段类型、缺失和分布，但这些结果主要作为 Markdown 交给 LLM。
-`select_charts(user_intent, available_columns, top_n)` 只接收字段名，无法可靠判断字段类型、
-基数、时间连续性、正负值、单位、粒度和数据点数量。
+数据概况已经能够计算字段类型、缺失和分布，但这些结果主要作为 Markdown 交给 LLM，尚未形成
+供 Planner 和 Validator 稳定消费的 `DataContext`。
 
 ### 2.4 通用参数接口承载了不同含义
 
 `run_analysis` 用 `target_column`、`groupby_column`、`n_deciles` 驱动多种分析。不同方法可能
-复用同一个参数表达目标字段、算法选项、分桶数量或聚类数量，导致参数难以类型化验证，
-也增加模型调用错误的风险。
+复用同一个参数表达目标字段、分组字段、分桶数量或聚类数量，导致参数难以类型化验证，也增加
+模型调用错误的风险。
 
-### 2.5 分析结果与呈现规划断开
+### 2.5 缺少统一分析结果契约
 
-分析模块返回 Markdown 和若干结果表，随后 LLM 再次依据上下文决定图表或文档。中间缺少
-统一 `AnalysisResult`，无法稳定声明核心指标、诊断、警告、来源、推荐图表和可用证据。
+分析模块目前可能返回 Markdown、三元组、四元组或命名字典。缺少统一 `AnalysisResult` 时，核心
+指标、诊断、警告、假设状态、来源和执行参数无法被稳定记录和测试。
 
-### 2.6 置信度和澄清策略不统一
+### 2.6 分析决策和澄清策略不统一
 
-Skill 检索、图表评分和 LLM 判断分别拥有不同阈值。第一、第二候选接近、数据条件不足、
-方法假设失败等情况没有统一的执行/澄清/拒绝策略。
+Skill 检索、LLM 判断和分析模块分别拥有不同规则。第一、第二候选接近、缺少必要字段、样本不足、
+数据质量阻塞或方法假设失败时，尚无统一的 `execute/clarify/blocked/fallback` 决策。
 
-### 2.7 规则分散导致维护漂移
+### 2.7 硬约束分散导致维护漂移
 
-同一方法的工作流和呈现建议可能同时存在于系统 Prompt、斜杠命令、Skill 和注册表中。
-新增或修改方法时需要人工保持多处一致，容易出现 Prompt 已更新但运行契约未更新的情况。
+同一方法的字段类型、最小样本量、参数范围和禁用条件可能同时存在于系统 Prompt、Skill、分析
+注册表和模块实现中。新增或修改方法时需要人工保持多处一致，容易形成新的漂移点。
 
-## 3. 目标与非目标
+### 2.8 图表相关命名边界
+
+当前代码中的两个名称承担不同职责，不能机械统一成同一个名称：
+
+- `select_chart`：`agent/tools/schemas.py` 暴露给 Agent 的对外工具名，使用单数；
+- `select_charts(...)`：`LLM/chart_selector.py` 内部返回多个候选的 Python 函数，使用复数；
+- `_tool_select_chart(...)`：现有工具适配层，调用内部 `select_charts(...)`。
+
+首期不修改这三个名称、调用关系或图表选择行为。
+
+## 3. 首期目标与非目标
 
 ### 3.1 目标
 
-1. 用统一 `AnalysisPlan` 记录一次分析的目标、数据、方法、参数、验证、输出和呈现计划。
-2. 让 LLM 负责语义理解和候选生成，让确定性代码负责数据兼容、方法条件和安全边界。
-3. 在执行前发现不适用方法、字段错误、参数冲突和证据不足。
-4. 用统一置信度和候选分差决定执行、澄清或停止。
-5. 让呈现方式同时考虑业务问题、数据形状、分析结果和受众，而非只匹配图表关键词。
-6. 保持现有公开工具入口兼容，允许渐进迁移和回退。
-7. 在代码提交前提供可复现的本地离线对照结果。
+1. 用统一 `AnalysisPlan` 记录一次分析的目标、数据、候选、方法、参数、验证和预期输出；
+2. 让 LLM 负责语义理解和有限候选生成，让确定性代码负责字段、数据和方法硬约束；
+3. 在执行前发现不适用方法、字段错误、参数冲突、样本不足和证据不足；
+4. 用统一置信度、候选分差和稳定 `reason_codes` 产生四种决策；
+5. 用 `AnalysisResult` 统一结果表、指标、诊断、警告、假设状态、来源和执行参数；
+6. 保持现有公开入口、Skill 和执行结果兼容，并提供明确回退路径；
+7. 在生产代码 PR 前提供可复现、经维护者抽审的本地离线对照结果。
 
-### 3.2 非目标
+### 3.2 非目标与后续范围
 
-- 本阶段不建设 AutoML 平台或自动超参数搜索系统。
-- 不允许 LLM 绕过确定性验证器直接执行不兼容计划。
-- 不一次性重写所有分析算法、图表实现和输出工具。
-- 不取消现有 Skill；Skill 继续承担方法 SOP 和用户可扩展能力。
-- 不在上游生产运行时长期维护双 Planner 或流量影子路径。
-- 本 RFC PR 不包含任何生产代码、测试数据或模型调用结果。
+以下内容不属于首期实现、文件修改或评测指标，后续如需推进应使用独立 RFC/PR：
 
-## 4. 建议目标架构
+- Presentation Planner；
+- Visualization Capability Registry 或现有图表注册表重构；
+- `select_chart`、`select_charts(...)` 或 `LLM/chart_selector.py` 再次重构；
+- 文本、表格、图表、报告或看板的呈现决策改造；
+- AutoML、自动超参数搜索或因果推断平台；
+- 一次性重写现有分析算法或输出工具。
+
+首期架构主链终止于 `AnalysisResult`，表示本阶段不改造下游呈现架构，并不取消呈现功能。
+`AnalysisResult` 产生后必须通过兼容适配继续进入当前呈现链；现有图表、报告和看板行为保持原样。
+
+本地离线影子只运行冻结案例，不进入真实用户请求。上游不长期维护双 Planner，也不接收仅用于
+运行时影子的独立 Planner PR。
+
+## 4. 首期 Analysis 目标架构
 
 ```mermaid
 flowchart TB
-    U["用户请求"] --> IP["Intent Parser\n结构化业务目标"]
-    DS["Schema + Data Profile"] --> CB["Context Builder"]
-    KB["指标口径 / 业务知识"] --> CB
-    IP --> CP["Candidate Planner"]
-    CB --> CP
-    AR["Analysis Capability Registry"] --> CP
-    CP --> PV["Plan Scorer + Validator"]
-    PV -->|"歧义或条件不足"| AU["ask_user"]
-    AU --> IP
-    PV -->|"验证通过"| AP["AnalysisPlan"]
-    AP --> EX["Execution Engine"]
-    EX --> RV["Result Validator\n假设与质量诊断"]
-    RV -->|"结果有效"| PP["Presentation Planner"]
-    RV -->|"方法不适用"| CP
-    VR["Visualization Capability Registry"] --> PP
-    PP --> T["文本 / 表格"]
-    PP --> C["图表"]
-    PP --> O["报告 / 看板"]
-    EX --> EV["Evidence + Provenance"]
-    RV --> EV
-    EV --> PP
+    subgraph PHASE1["首期 Analysis 实施边界"]
+        U["用户请求"] --> IP["Intent Parser\nAnalysisIntent"]
+        DS["Schema + Data Profile"] --> CB["Context Builder\nDataContext"]
+        KB["指标口径 / 业务知识"] --> CB
+        IP --> CP["Analysis Candidate Planner"]
+        CB --> CP
+        CR["Analysis Capability Registry"] --> CP
+        CP --> PV["Deterministic Plan Validator"]
+        CB --> PV
+        CR --> PV
+        PV --> AP["AnalysisPlan\n+ reason_codes"]
+        AP --> D{"decision"}
+        D -->|"clarify"| AU["ask_user"]
+        AU --> IP
+        D -->|"blocked"| BL["结构化阻塞结果"]
+        D -->|"fallback"| FB["结构化描述性降级建议"]
+        D -->|"execute"| EX["Analysis Executor"]
+        EX --> RV["Result Validator\n假设与质量诊断"]
+        RV --> AR["AnalysisResult"]
+    end
+    AR -. "兼容交接；首期不改造" .-> EXISTING["现有解释与呈现链"]
 ```
 
-核心边界是：
+主链和职责边界如下：
 
-- **LLM**：理解用户语义、补全业务目标、生成有限候选、解释有效结果。
-- **确定性 Planner/Validator**：验证字段类型、方法条件、参数、置信度和候选分差。
-- **执行层**：只执行已经验证的计划，不负责重新解释用户意图。
-- **呈现层**：根据结构化结果选择表现形式，不从原始用户句子重新猜测。
+- **LLM**：理解用户语义、补全业务目标、生成有限候选，不声明数据硬约束已经满足；
+- **Analysis Candidate Planner**：归一化候选、应用显式方法优先级并计算可比较分数；
+- **确定性 Plan Validator**：验证字段、类型、样本、质量、参数、依赖、方法假设和候选分差；
+- **执行层**：只执行已经验证的计划，不重新解释用户意图；
+- **Result Validator**：记录执行后诊断、警告和假设状态，不选择呈现形式；
+- **现有呈现链**：通过兼容输出继续工作，不属于首期架构改造范围。
 
 ## 5. 核心数据契约
+
+所有契约都带独立 `schema_version`，采用可序列化、可测试的 JSON 兼容字段；动态解释文本与稳定
+机器码分离。
 
 ### 5.1 AnalysisIntent
 
 ```text
-goal                 描述 | 比较 | 诊断 | 解释 | 预测 | 分群
-question_type        趋势 | 关系 | 构成 | 分布 | 异常 | 分类 | 预测
-target               目标指标或标签
-dimensions           分组、对比和切片维度
-time_scope           时间范围、频率和预测期
-audience             分析师 | 业务负责人 | 管理层
-artifact             对话 | 图表 | 报告 | 看板 | 导出
-constraints          可解释性、速度、精度和业务限制
-ambiguities          尚未确定且可能改变方法的事项
+schema_version
+goal                 describe | compare | diagnose | relate
+                     classify | predict | cluster
+question
+target
+features[]
+dimensions[]
+time_column / id_columns[]
+time_scope / forecast_horizon
+requested_method
+constraints
+ambiguities[]
+language             zh | en | mixed
 ```
+
+`requested_method` 表示用户明确指定的方法，但不能绕过 Validator。`ambiguities` 只记录会实质改变
+方法或字段角色的问题，避免对不影响决策的细节过度澄清。
 
 ### 5.2 DataContext
 
 ```text
+schema_version
 table / source
 row_count
 columns[]
+  - name
   - physical_type
-  - semantic_role
+  - semantic_roles[]
   - nullable / missing_rate
   - cardinality
   - numeric_range / allows_negative
+  - class_distribution
   - time_frequency / continuity
 grain
 metric_contracts
-quality_warnings
+quality_warnings[]
 ```
 
-`profile_data` 可继续输出人类可读 Markdown，但同时应提供稳定 JSON 结构供 Planner 使用。
+`profile_data` 可继续输出人类可读 Markdown，同时提供或派生稳定 JSON 结构供 Planner 使用。
+语义角色推断必须保留证据和置信度；不能只根据列名把 ID 当作连续数值特征。
 
 ### 5.3 AnalysisCapability
 
 每个分析方法在注册表中声明：
 
 ```text
+schema_version
 method_id
-supported_goals
+supported_goals[]
+selection_mode        automatic | explicit_only
 input_roles_and_types
 minimum_data_requirements
+data_quality_requirements
 preconditions
 incompatibilities
 parameter_schema
-required_diagnostics
+runtime_dependencies[]
+required_diagnostics[]
 output_contract
-presentation_hints
-cost_and_explainability
 ```
 
-### 5.4 AnalysisPlan
+字段角色、类型、样本量、参数 Schema、依赖、前置条件、禁用条件和输出契约都是机器可验证硬约束。
+约束使用稳定 `constraint_id + args` 表达，不允许在元数据中保存不可序列化 Lambda。通用模型或
+神经网络入口可以标记为 `explicit_only`，避免首期演变为 AutoML。
+
+### 5.4 AnalysisCandidate
 
 ```text
+schema_version
+method_id
+semantic_score
+field_roles
+parameters
+proposal_source       explicit_user | llm | legacy_adapter
+```
+
+LLM 只提交有限候选及语义证据。旧 `run_analysis` 调用可被兼容适配为一个 `legacy_adapter` 候选，
+但仍必须经过相同 Validator。
+
+### 5.5 AnalysisPlan
+
+```text
+schema_version
+reason_code_version
+decision              execute | clarify | blocked | fallback
 intent
-dataset
+data_context_ref
 method_id
 field_roles
 parameters
-prechecks
-expected_outputs
-presentation_hints
+prechecks[]
+expected_outputs[]
 confidence
 runner_up_margin
-reason_codes
+reason_codes[]
+validation_errors[]
+candidate_summary[]
 ```
 
-### 5.5 AnalysisResult 与 PresentationPlan
+每个 `validation_errors[]` 元素至少包含 `constraint_id`、相关字段或角色、`expected`、`actual` 和
+人类可读 `message`；动态值只进入这里，不进入稳定 `reason_codes` 枚举。
 
-`AnalysisResult` 统一描述结果表、核心指标、诊断、警告、假设状态、数据来源和执行参数。
-`PresentationPlan` 再根据问题、受众、结果类型和数据规模选择文本、表格、图表、报告或看板。
+### 5.6 AnalysisResult
 
-## 6. 方法选择与澄清策略
+```text
+schema_version
+reason_code_version
+plan_ref / method_id
+result_tables[]
+metrics
+diagnostics
+warnings[]
+assumption_status[]
+data_provenance
+execution_parameters
+compatibility_markdown
+```
 
-候选方法建议从以下维度评分：
+`AnalysisResult` 是首期架构终点，但不是用户交互终点。执行适配器将其投影为现有 Markdown 和结果
+表契约，随后继续调用现有呈现链；首期不在 `AnalysisResult` 中新增图表或报告选择。
+
+## 6. 候选、验证与统一决策
+
+### 6.1 候选排序
+
+候选方法使用以下信息排序：
 
 1. 用户目标和问题类型匹配度；
-2. 字段角色、数据类型和样本量兼容性；
-3. 数据质量和方法假设满足程度；
-4. 用户对准确性、速度和可解释性的要求；
-5. 计算成本；
-6. 用户明确指定的方法偏好；
-7. 第一候选与第二候选的分差。
+2. 用户是否明确指定方法；
+3. 字段角色和语义适配度；
+4. 用户对准确性、速度和可解释性的约束；
+5. 第一候选与第二候选的分差。
 
-决策输出只能是：
+样本量、字段类型、数据质量、参数范围、依赖和方法假设不作为可以被高语义分数抵消的软分数，
+而由 Validator 作为硬约束处理。
 
-- **execute**：候选通过全部硬约束，置信度及分差达到门槛；
-- **clarify**：多个合法候选会产生实质不同结论，或缺少会改变方法的业务信息；
-- **blocked**：数据不满足任何方法的必要条件；
-- **fallback**：高级方法不适用，但存在经过验证的简单描述性方案。
+### 6.2 决策规则
 
-每次决定都返回稳定 `reason_codes`，便于测试、日志分析和向用户解释。
+Planning Service 只能输出以下四种决策：
 
-## 7. 可视化与呈现规划
+- **execute**：候选通过全部硬约束，且满足语义置信度和候选分差软门槛；用户明确指定且合法的
+  方法不受语义置信度或候选分差软门槛影响；
+- **clarify**：语义歧义会改变方法或字段角色；或者用户未明确指定合法方法时，最高合法候选的
+  语义置信度低于门槛，或第一、第二合法候选分差低于门槛；
+- **blocked**：缺少必要字段、数据不满足任何方法的硬约束，或没有可安全执行的候选；
+- **fallback**：高级方法不合法，但仍存在经过验证的描述性分析；不能静默改选另一个高级方法。
 
-图表注册表应逐步升级为可视化能力注册表，除图表名称和字段角色外，还声明：
+建议初始语义置信度门槛为 `0.70`，合法候选的 runner-up margin 门槛为 `0.15`；它们是待维护者
+确认并由冻结评测校准的软门槛。硬约束不因阈值调低而放宽。
 
-- 支持的分析目标和结果类型；
-- 每个 role 的字段类型；
-- 类别基数、数据点数量和系列数范围；
-- 是否允许负值、是否需要排序或归一化；
-- 禁用条件和降级图表；
-- 对应的解释模板和无障碍要求。
+`clarify`、`blocked` 和 `fallback` 都是可测试的正常决策，不应伪装成工具异常。只有 `execute`
+进入对应分析实现；未执行决策不得写分析结果表。
 
-Presentation Planner 不应把“用户提到关系”直接等价为散点图，而应先判断：
+## 7. 稳定 reason_codes v1
 
-- 是否已有统计分析结果；
-- x/y 是否为数值字段；
-- 是否需要展示置信区间、残差、预测区间或类别分组；
-- 受众需要精确表格、诊断视图还是管理摘要；
-- 是否根本不需要图表。
+首期版本标识为 `analysis-reason-codes/v1`。以下枚举覆盖候选依据、验证通过、澄清、阻塞和降级：
 
-## 8. 兼容与迁移策略
+| 类别 | reason code | 稳定语义 |
+|---|---|---|
+| 目标与偏好 | `analysis_goal_matched` | 候选支持结构化分析目标 |
+| 目标与偏好 | `analysis_user_method_requested` | 用户明确指定该方法；仍需通过硬约束 |
+| 验证通过 | `analysis_field_roles_compatible` | 必要字段角色与类型兼容 |
+| 验证通过 | `analysis_sample_size_sufficient` | 样本量满足方法下限 |
+| 验证通过 | `analysis_data_quality_passed` | 缺失、类别分布或时间连续性等质量门禁通过 |
+| 验证通过 | `analysis_assumptions_satisfied` | 可在执行前验证的方法假设成立 |
+| 澄清 | `analysis_intent_ambiguous` | 存在会改变方法或字段角色的语义歧义 |
+| 澄清 | `analysis_semantic_confidence_too_low` | 非显式候选的语义置信度低于软门槛 |
+| 澄清 | `analysis_candidate_margin_too_low` | 第一、第二合法候选分差低于门槛 |
+| 阻塞 | `analysis_required_field_missing` | 缺少方法所需字段角色 |
+| 阻塞 | `analysis_target_type_incompatible` | 目标字段类型与方法不兼容 |
+| 阻塞 | `analysis_sample_size_insufficient` | 总体、分组或类别样本量不足 |
+| 阻塞 | `analysis_data_quality_blocked` | 缺失、失衡或时间连续性等质量问题阻止执行 |
+| 阻塞 | `analysis_assumption_violated` | 已验证的方法假设不成立 |
+| 阻塞 | `analysis_parameter_invalid` | 参数缺失、类型错误、冲突或超出允许范围 |
+| 阻塞 | `analysis_dependency_unavailable` | 必需运行时依赖不可用 |
+| 阻塞 | `analysis_no_valid_candidate` | 所有候选均被过滤且无可执行方法 |
+| 降级 | `analysis_descriptive_fallback_selected` | 已选择经过验证的描述性降级方案 |
 
-### 8.1 保持现有入口
+兼容与测试规则：
 
-- `run_analysis(...)` 保留，内部可以逐步转为执行已经验证的计划。
-- `select_charts(...)` 保留为兼容适配器；新接口可接收 `DataContext` 和 `AnalysisResult`。
-- `generate_chart(...)` 继续负责渲染，但在渲染前增加类型化数据契约校验。
-- Skill 继续存在，逐步把重复的硬约束迁移到能力注册表，Skill 保留业务 SOP 和解释要求。
-- 斜杠命令继续工作，不要求用户改变已有使用方式。
+- v1 中已发布的值不得重命名、删除或改变语义；同一 major 下只能追加；
+- 破坏性变化发布新 major，例如 `analysis-reason-codes/v2`，并至少保留一个发布周期的旧值映射；
+- 读取端保留未知 code，不能因出现新 code 丢弃整个计划或结果；
+- `reason_codes` 按本节枚举顺序输出并去重，每个决策至少包含一个能够解释该决策的 code；
+- 动态字段名、阈值、实际值和自然语言消息进入 `validation_errors`，不生成临时 reason code；
+- `AnalysisPlan`、`AnalysisResult` 和评测记录显式携带 `reason_code_version`。
 
-### 8.2 可回退
+## 8. Skill 硬约束迁移与兼容策略
 
-新 Planner 需要配置开关。若代码 PR 上线后发现回归，可以切回现有决策路径；执行算法、图表
-渲染器和数据源接口不随 Planner 重写，从而缩小回退范围。
+### 8.1 规则所有权
 
-## 9. 本地离线影子评测方案
+| 位置 | 保留内容 | 不得承担的内容 |
+|---|---|---|
+| Capability Registry | 类型、样本量、参数、依赖、前置/禁用条件、输出契约 | 业务沟通与解释文案 |
+| Skill | 业务 SOP、指标口径确认、泄漏提醒、解释要求、用户沟通、方法使用建议 | 覆盖、放宽或另行定义 Registry 硬约束 |
+| Prompt / 命令提示 | 引导工具调用和收集结构化意图 | 复制数值阈值、参数枚举或指示绕过 Validator |
+| 分析模块 | 与 Registry 一致的防御性输入检查 | 成为调用前适用性判断的另一真相源 |
 
-### 9.1 原则
+当 Skill、Prompt、旧调用参数或 LLM 候选与 Registry 冲突时，Registry 和 Validator 始终优先。
+用户/工作区 Skill 覆盖同名内置 Skill 时也不能改变这一优先级。
 
-影子 Planner 不作为独立上游 PR，也不进入生产流量路径。维护者认可本 RFC 后，贡献者在本地
-分支实现候选 Planner，并让新旧 Planner 对同一批冻结案例独立生成决策，执行结果不展示给
-真实用户，也不写入真实业务数据。
+### 8.2 迁移步骤与去重
 
-只有评测结果达到约定门槛，才提交生产代码 PR。实现 PR 同时附带评测摘要和可复现说明。
+1. **盘点**：为每个内置 Analysis Skill 建立 `method_id` 映射，列出 Skill、Prompt、Registry 和
+   分析模块中的现有硬约束及来源；
+2. **双轨校验**：先把约束结构化迁入 Capability，保留模块防御性检查；使用边界与无效 fixture
+   验证 Registry 拒绝条件和模块实际行为一致；
+3. **禁止放宽**：所有执行入口在 Skill 或 Prompt 逻辑之外统一调用 Validator；契约测试证明激活
+   任意内置、用户或工作区 Skill 都不能绕过硬约束；
+4. **删除重复**：Capability 成为硬约束真相源后，删除 Skill 和 Prompt 中重复的字段类型、数值
+   阈值、参数枚举和“即使无效也强制执行”等规则；Skill 改为引用 `method_id`；
+5. **持续检测**：CI 校验 Skill 引用的方法存在，禁止 Skill frontmatter 声明机器硬约束字段，并以
+   每个 capability 的无效样本回归测试检测 Registry、执行入口与模块防御检查的漂移。
 
-### 9.2 冻结评测集
+迁移期间的约束盘点随代码 PR 提交；完成后不保留第二套可修改的 Skill 硬约束副本。
 
-建议至少 100 个匿名、合成或公开可分享案例，覆盖：
+### 8.3 保持现有入口和行为
 
-- 描述统计、趋势、关系、构成、分布、分类、预测和聚类；
-- 数值、类别、时间、地理、ID 和文本字段组合；
-- 样本不足、目标类型错误、缺失严重、类别失衡和时间不连续；
-- 第一、第二候选接近，需要澄清的歧义场景；
+- `run_analysis(...)` 工具名和现有必填参数保持兼容，内部逐步执行经过验证的计划；
+- `select_chart` 对外工具、`select_charts(...)` 内部函数和 `_tool_select_chart(...)` 适配层均保持不变；
+- `generate_chart(...)`、报告、看板和现有分析后呈现链不在首期改造；
+- 兼容范围覆盖 `commands/` 当前实际注册的斜杠命令、用户/工作区 prompt command 和 Analysis Skill，
+  不把已经没有注册的遗留分析命令当作现状；
+- 旧分析模块的三元组、四元组和命名字典返回值由 `AnalysisResult` 适配器归一化；
+- 同步与后台 Job 路径共享同一 Validator，并完整传递 `analysis_options`。
+
+### 8.4 回退
+
+候选实现提供 `validated` 与 `legacy` 模式开关，但不提供 `shadow` 运行时模式。生产代码 PR 达标后
+默认使用 `validated`；如出现回归，可切回 `legacy` 并重启。两种模式均继续进入同一现有呈现链。
+首期无数据库迁移、无真实流量影子、无双写，回退不删除用户数据。
+
+## 9. 本地离线影子评测
+
+### 9.1 执行原则与审批顺序
+
+PR 合并或维护者明确批准后，贡献者才从届时最新 `upstream/main` 创建独立本地实现 worktree 与
+分支。先冻结案例并测量旧路径基线，再实现候选 Planning Service。新旧逻辑只对相同 fixture 或
+临时数据源离线运行，不处理真实用户请求，不写真实业务数据。
+
+纯 Planner/Validator 达到决策门槛后，才在本地接入 `run_analysis` 做完整兼容评测。全部门槛达到
+后才提交生产代码 PR；未达到就继续本地修订或停止，不提交不成熟实现。
+
+### 9.2 冻结评测集与维护者抽审
+
+公开评测集使用匿名、合成或公开可分享案例，不少于 100 例，建议 112 例，即七种目标各 16 例。
+至少覆盖：
+
+- describe、compare、diagnose、relate、classify、predict 和 cluster；
+- 数值、类别、时间和 ID 字段及其组合；
+- 目标类型错误、样本不足、严重缺失、类别失衡和时间不连续；
+- 应澄清和不应澄清的案例；
 - 中文、英文和中英混合表达；
-- 文本、表格、单图、多图、报告和看板呈现目标；
-- 现有斜杠命令和 Skill 的关键兼容场景。
+- `commands/` 中当前注册的斜杠命令、用户/工作区 prompt command 和 Analysis Skill 兼容场景。
 
-案例只保存结构化意图、匿名 schema/profile、预期决策和判定理由，不包含密钥或未经授权的
-真实业务数据。
+评测集使用 canonical JSONL，manifest 记录版本、SHA-256、冻结时间、覆盖统计、标签规范和审核方式。
+冻结后修改任何输入或期望值都必须发布新版本和 hash，并重新运行 baseline 与 candidate。
+
+冻结前采用以下任一治理方式：
+
+1. 维护者按目标、语言和失败类型分层抽审至少 20%，且不少于 20 例；或
+2. 维护者提供不少于 20 个隐藏/保留案例，由维护者运行或只向贡献者返回汇总结果。
+
+贡献者不能根据隐藏案例逐条硬编码。生产代码 PR 附评测摘要，但不泄漏隐藏数据、提示或可逆推出
+案例内容的信息。如果维护者暂时无法提供案例，贡献者必须先请求其确认采用哪种抽审方式，不能
+自行假定评测集已经通过独立审题。
 
 ### 9.3 对照记录
 
-每个案例记录：
+每次运行对每个案例至少记录：
 
 ```text
 case_id
+evaluation_version / evaluation_hash
 baseline_commit / candidate_commit
-model_provider / model / temperature
-input_intent / data_context
+model_provider / model / temperature / repetitions
+analysis_intent / data_context
 baseline_decision / candidate_decision
-expected_method / expected_presentation
-confidence / runner_up_margin / reason_codes
+expected_method / expected_decision
+confidence / runner_up_margin
+reason_code_version / reason_codes
 validation_errors
 latency / model_calls
-pass_or_fail / reviewer_note
+pass_or_fail / failure_class / reviewer_note
 ```
 
-若模型无法设置完全确定性参数，对候选 Planner 重复运行三次并记录一致率。
+失败分类固定为：`intent_parsing`、`data_context`、`capability_metadata`、`candidate_scoring`、
+`validation`、`execution_contract` 和 `compatibility`。若模型不能使用确定性参数，每例重复运行三次
+并记录决策一致率。
 
-### 9.4 建议提交门槛
+### 9.4 建议门槛
 
-正式阈值由维护者确认。初始建议为：
+以下门槛只作为 RFC 建议，必须由维护者确认；没有基线时不得伪造提升结果：
 
-- 方法选择准确率较基线提升至少 10 个百分点；
-- 数据不兼容计划比例下降至少 50%，且不高于 5%；
-- 呈现形式适配准确率较基线提升至少 10 个百分点；
-- 应澄清案例的召回率不低于 90%；
-- 不应澄清案例的误澄清率相对基线恶化不超过 5 个百分点；
-- 现有命令、Skill、工具 Schema 和分析执行测试无回归；
-- 新增模型调用和 P95 延迟在维护者接受的预算内；
-- 所有失败案例均分类为意图解析、数据上下文、能力元数据、评分、验证或呈现问题。
+- `(decision, method)` 联合准确率比基线提高至少 10 个百分点；
+- 非法执行率比基线下降至少 50%，且不高于 5%；维护者保留集不得出现高严重度非法执行；
+- 应澄清案例召回率不低于 90%；
+- 不应澄清误报率相对基线恶化不超过 5 个百分点；
+- 主要目标和语言切片不得下降超过 5 个百分点；
+- Skill、当前命令、工具 Schema、同步/Job 执行、输出表和现有呈现链兼容用例 100% 通过；
+- 平均模型调用数不超过基线 `+0.25`，P95 延迟不超过基线 `+20%`；
+- 需要重复运行时，候选决策一致率至少 95%。
 
-评测报告应同时展示绝对数量、比例和失败案例，不只报告一个总分。
+评测报告展示绝对数量、比例、切片和失败分类，不只报告总分。
 
-### 9.5 提交流程
+### 9.5 提交流程与审批门
 
 ```text
-RFC 文档 PR（当前）
-    ↓ 维护者认可方向和评测门槛
-本地建立冻结评测集并测量旧路径基线
-    ↓
-本地实现候选 Planner 与兼容适配器（不提交影子 PR）
-    ↓
-本地离线影子对照，记录结果和失败分类
-    ↓ 达到门槛
-提交生产代码 PR，并附评测摘要、兼容性和回退说明
+修订 RFC PR（当前）
+    ↓ 维护者合并，或明确批准实现、抽审方式和门槛
+本地冻结评测集并测量旧路径基线
+    ↓ 抽审方式、版本/hash 与基线记录完整
+本地实现纯 Analysis Planner / Validator
+    ↓ 决策门槛达到
+本地接入 run_analysis 并完成执行、兼容和回退评测
+    ↓ 全部门槛达到且独立审查通过
+提交一个 Analysis 侧生产代码 PR并附评测摘要
 ```
 
-如果未达到门槛，继续在本地修订或停止方案，不把不成熟的 Planner 提交给上游维护。
+代码 PR 不包含运行时影子路径。提交前向维护者说明 baseline/candidate SHA、评测 hash、绝对数量、
+比例、失败分类、延迟、模型调用、兼容性和回退方案。
 
-## 10. 预期收益
+## 10. 首期测试与验收范围
 
-### 10.1 分析正确性
-
-方法选择从“语义上像某个 Skill”升级为“目标匹配且数据条件验证通过”，减少分类目标调用线性
-回归、短时间序列调用复杂预测模型、类别过多仍使用饼图等错误。
-
-### 10.2 可解释与可审计
-
-`AnalysisPlan` 保存方法、字段、参数、置信度和 `reason_codes`。用户和维护者可以回答“为什么
-这样分析”，测试也可以直接断言决策，不再只能检查最终文本。
-
-### 10.3 更一致的澄清体验
-
-所有方法和呈现选择共享执行/澄清/阻塞标准，避免图表会澄清、分析方法却直接猜测的行为差异。
-
-### 10.4 更可靠的呈现
-
-呈现方式由结构化结果驱动，预测可以稳定带预测区间，回归可以带系数和诊断，管理层输出可以
-优先结论和风险，而不是仅根据原始用户措辞选一个图表。
-
-### 10.5 更低的长期维护成本
-
-新增分析方法时，开发者在能力注册表中声明输入、条件、输出和呈现提示，减少在 Prompt、Skill、
-命令和工具描述之间重复维护规则。
-
-### 10.6 更安全的开源演进
-
-本地离线影子评测把架构重构从“凭感觉提交”变成“先给基线和对照证据”。上游不需要先合并
-运行时双路径，也不会让真实用户承担试验风险。
+- **单元测试**：契约序列化、`DataContext` 类型与角色推断、reason code 顺序和去重、候选排序、
+  每种硬约束及四种决策；
+- **能力契约测试**：当前注册的全部分析方法都有合法 capability，方法 ID、参数 Schema、依赖和
+  输出契约与旧注册信息一致；
+- **Skill 一致性测试**：Skill 引用的方法存在，不能声明或放宽硬约束，无效 fixture 始终被
+  Validator 拒绝；
+- **执行集成测试**：只有合法 `execute` 计划进入分析器；其他决策不写表；同步/Job 路径一致，
+  `analysis_options` 不丢失，现有返回形状均可归一化；
+- **兼容回归测试**：现有 `run_analysis` Schema、结果表、工具暴露、workflow stage 和分析后的
+  呈现链不变；现有 chart selector 测试继续通过，首期 diff 不包含 chart selector 或 Presentation 改造；
+- **评测协议测试**：manifest/hash 可复现，必填记录齐全，未知 reason code 可向前兼容；
+- **独立审查**：非实现者复核 RFC 对齐、执行门禁、数据泄漏、评测可复现性和回退路径；未解决的
+  高或中优先级问题阻止生产代码 PR。
 
 ## 11. 成本与风险
 
 | 风险 | 影响 | 缓解方式 |
 |---|---|---|
-| 能力元数据维护成本 | 新方法需要声明更多契约 | 提供公共默认值、Schema 校验和注册模板 |
-| Planner 增加延迟 | 多一次结构化规划或验证 | 优先本地确定性过滤，仅对歧义调用 LLM |
-| 离线案例代表性不足 | 本地结果可能高估真实效果 | 覆盖失败场景、语言变化和数据形状；后续只记录匿名反馈指标 |
-| 规则过严 | 合法分析被阻止 | 提供 fallback、reason code 和可配置软门槛 |
-| 规则与 Skill 再次重复 | 形成新的漂移点 | 能力注册表负责硬约束，Skill 只负责 SOP 和解释 |
-| 重构范围过大 | PR 难审查、回归范围大 | 由维护者决定单 PR 或按稳定接口拆分；每步保留适配器 |
+| 能力元数据维护成本 | 新方法需要声明更多契约 | 提供 Schema 校验、注册模板和行为一致性测试 |
+| Planner 增加延迟 | 结构化规划可能增加耗时 | 优先在同一次模型调用中生成意图和候选；确定性过滤不调用模型 |
+| 离线案例代表性不足 | 本地结果可能高估真实效果 | 冻结 hash、覆盖失败切片并由维护者抽审或提供保留集 |
+| 规则过严 | 合法分析被阻止 | 提供 clarify、fallback、稳定 reason code 和可校准软门槛 |
+| Skill 与 Registry 再次重复 | 形成新的漂移点 | Registry 作为唯一硬约束源，禁止 Skill 放宽并持续运行一致性测试 |
+| 旧返回形状不一致 | 合法模块无法进入统一结果契约 | 在执行适配器归一化并覆盖三元组、四元组和命名字典测试 |
+| 首期范围再次扩大 | 叠加 chart_selector 或呈现回归 | 首期主链止于 AnalysisResult；呈现架构使用独立 RFC/PR |
 
 ## 12. 后续代码范围草案（本 PR 不实施）
 
-可能新增或调整的模块边界：
+首期生产代码 PR 预计只涉及 Analysis 侧边界：
 
 ```text
-agent/planning/models.py          AnalysisIntent / DataContext / AnalysisPlan
+agent/planning/models.py          AnalysisIntent / DataContext / AnalysisPlan / AnalysisResult
 agent/planning/context.py         schema/profile/knowledge 结构化上下文
-agent/planning/candidates.py      候选分析方法生成
-agent/planning/policy.py          评分、置信度、分差与澄清策略
-agent/planning/validator.py       方法和字段适用性验证
-agent/presentation/planner.py     文本、表格、图表和文档规划
+agent/planning/candidates.py      候选分析方法归一化与排序
+agent/planning/validator.py       方法、字段、样本、质量、参数和依赖验证
+agent/planning/service.py         execute / clarify / blocked / fallback 统一决策
+agent/planning/executor.py        已验证计划执行与 AnalysisResult 兼容适配
 Function/Analyze/registry.py      扩展 AnalysisCapability 元数据
-LLM/chart_selector.py             保留兼容入口，接入类型化可视化约束
-agent/tools/business/data.py      执行已验证计划并返回 AnalysisResult
+agent/tools/business/data.py      在现有 run_analysis 路径接入验证与结果适配
+evaluation/analysis_planning/     冻结协议、案例、runner 与评测摘要
+tests/test_analysis_*.py          单元、契约、集成、兼容和评测协议测试
 ```
 
-实际文件和 PR 粒度以维护者反馈为准。
+`agent/prompts.py`、Skill 解析代码或 Analysis `SKILL.md` 只在迁移重复硬约束所必需时调整。
+`agent/workflow_stage.py` 原则上不修改，以回归测试证明路由不变。
 
-## 13. 请求反馈
+Presentation Planner、Visualization Registry、`LLM/chart_selector.py`、报告和看板呈现决策明确留给
+后续独立 RFC/PR。首期 `AnalysisResult` 仍通过兼容适配进入这些现有流程。
 
-如果维护者认为问题判断和方向合理，希望确认第 0 节的三个问题，尤其是：
+## 13. 请求重新审查
 
-- 是否接受统一 `AnalysisPlan` 和能力注册表作为后续演进方向；
-- 是否接受在贡献者本地完成离线影子评测、随代码 PR 提交结果摘要，而不先合并运行时影子路径；
-- 希望后续实现以一个完整 PR 还是多个稳定接口 PR 提交。
+请维护者重点确认：
 
-收到方向确认后，再建立本地评测集和实现计划；在此之前不修改生产行为。
+- 第 2.8 节对 `select_chart`、`select_charts(...)` 和 `_tool_select_chart(...)` 的命名边界；
+- 第 8 节的 Skill 硬约束迁移、去重和唯一真相源规则；
+- 第 9.2 节采用维护者抽审还是隐藏/保留案例；
+- 第 7 节的 `reason_codes` v1 与第 9.4 节建议门槛；
+- 第 3、4、12 节的 Analysis 首期范围与 Presentation 后续拆分。
+
+收到合并或明确实施许可前，不修改生产行为。


### PR DESCRIPTION
## 目的

这是一个仅包含文档的 RFC，用于在开始生产代码改造前征求维护者意见。

当前分析方法选择分散在 Skill 检索、Prompt、LLM 判断、分析注册表和图表规则中。本提案建议增加统一、结构化且可验证的 `AnalysisPlan`，让 LLM 负责语义理解与有限候选生成，让确定性代码负责数据适用性、参数、置信度和澄清边界。

## 这份 RFC 提议什么

- 引入 `AnalysisIntent`、`DataContext`、`AnalysisCapability`、`AnalysisPlan`、`AnalysisResult` 和 `PresentationPlan` 契约。
- 扩展分析与可视化注册表，使其描述输入类型、前置条件、禁用条件、诊断和输出契约，而不只描述执行入口。
- 统一 execute / clarify / blocked / fallback 决策和 reason codes。
- 保持现有 Skill、`run_analysis`、`select_charts` 和 `generate_chart` 公共入口兼容。
- 不提交独立的运行时影子 Planner PR；维护者认可方向后，先在贡献者本地完成离线影子对照并记录结果，达到门槛后才提交生产代码 PR。

## 为什么这样做

- 在执行前发现方法与字段类型、样本量或数据质量不兼容的问题。
- 让“为什么选择这个方法和呈现方式”可解释、可测试、可审计。
- 统一低置信度时的澄清行为，减少 LLM 直接猜测。
- 让呈现形式由业务问题、数据形状、分析结果和受众共同决定。
- 减少 Prompt、Skill、命令和注册表之间的重复规则与维护漂移。
- 先提供本地基线和对照证据，不让上游或真实用户承担实验性双 Planner 风险。

## 本 PR 的实际变更

- 仅新增 `docs/15-analysis-planning-architecture-rfc.md`。
- 没有修改生产代码、测试、工具 Schema、模型调用或运行行为。
- 没有开始实现 Planner。

## 希望维护者确认

1. 是否认可统一 `AnalysisPlan` 和能力注册表作为后续演进方向？
2. 是否接受在贡献者本地完成离线影子评测，并随未来代码 PR 附上结果摘要，而不先合并运行时影子路径？
3. 如果方向可行，希望后续代码使用一个完整 PR，还是按数据契约、能力注册表、Planner 和 Presentation Planner 拆分提交？

如果方向或范围不符合项目路线，欢迎直接指出；在得到确认前不会开始生产代码改造。

## 验证

- `git diff --check upstream/main...HEAD`
- Git diff 仅包含一份 RFC 文档
- 文档无占位符，Mermaid/代码围栏闭合，引用的当前代码路径均存在
